### PR TITLE
Specify the default mode for the AES cipher

### DIFF
--- a/flask_user/tokens.py
+++ b/flask_user/tokens.py
@@ -19,7 +19,7 @@ class TokenManager(object):
             key = secret + precursor
         else:
             key = secret.encode("utf-8") + precursor
-        self.cipher = AES.new(key[0:16])
+        self.cipher = AES.new(key[0:16], AES.MODE_ECB)
 
         # Create signer to sign tokens
         self.signer = TimestampSigner(secret)


### PR DESCRIPTION
By specifying the mode for the AES cipher the code is compatible with both PyCrypto & PyCryptodome which requires the mode to be specified
